### PR TITLE
Modify Dokerfile to remove unsuported `lerna link` command (legacy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ COPY landing-zone-accelerator-on-aws .
 COPY lza-validator.sh ./lza-validator.sh
 
 RUN mkdir config
+RUN apk add git
 RUN cd source \
     && export NODE_OPTIONS=--max_old_space_size=8192 \
     && yarn install \
-    && yarn lerna link \
     && yarn build \
     && yarn cache clean
 

--- a/build.sh
+++ b/build.sh
@@ -23,5 +23,3 @@ for release in $latest_n_releases; do
   cd ..
   $tooling build -t lza-validator:$release .
 done
-
-


### PR DESCRIPTION
*Issue #, if available:*
Broken container build, errors:

- https://lerna.js.org/docs/legacy-package-management
- `husky - git command not found, skipping install`

*Description of changes:*
Modify Dokerfile to remove unsuported `lerna link` command (legacy) and to install `git`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
