### PR TITLE
fix: Correctly sort versions before build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ fi
 cd landing-zone-accelerator-on-aws
 git checkout main
 git pull
-tags=$(git tag)
+tags=$(git tag | sort -V)
 latest_n_releases=$(echo $tags | rev | cut -d ' ' -f 1-$n | rev)
 cd ..
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
With latest release of LZA we need to sort using semantic version ordering to get correct latest version selected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
